### PR TITLE
Feature/camelcase Add camelCase support, async install, and CRD schema improvements

### DIFF
--- a/kubecrd/schemabase.py
+++ b/kubecrd/schemabase.py
@@ -32,15 +32,6 @@ def to_snake_case(camel_str):
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
 
-# def to_camel_case(snake_str):
-#     components = snake_str.split("_")
-#     return components[0] + "".join(x.title() for x in components[1:])
-
-
-# def to_snake_case(camel_str):
-#     return re.sub(r"(?<!^)(?=[A-Z])", "_", camel_str).lower()
-
-
 class KubeResourceBase:
     """KubeResourceBase is base class that provides methods to converts dataclass
     into Kubernetes CR. It provides ability to create a Kubernetes CRD from the


### PR DESCRIPTION
### Summary

This PR adds support for:
- camelCase field transformation during (de)serialization
- missing CRD fields like shortNames and status
- asynchronous install method for CRDs using `kubernetes_asyncio`

### Why

This allows better alignment with Kubernetes field naming conventions and enables async-native environments.

### Notes

- No breaking changes
- Uses `to_camel_case()` and `to_snake_case()` helpers
